### PR TITLE
Change the dropdown menus to align right

### DIFF
--- a/src/Header.js
+++ b/src/Header.js
@@ -89,10 +89,10 @@ class Header extends React.Component {
                 <Form inline>
                     <Navbar.Collapse className="mr-sm-2">
                         <Nav>
-                            <NavDropdown title="Support Quick Bench" id="basic-nav-dropdown">
+                            <NavDropdown title="Support Quick Bench" id="basic-nav-dropdown" alignRight>
                                 <DropdownItem href="https://www.patreon.com/bePatron?u=8599781" target="_blank"><img src="ico/Patreon.svg" className="line-img" alt="Patreon icon" /> Support on Patreon</DropdownItem>
                             </NavDropdown>
-                            <NavDropdown title="More" id="basic-nav-dropdown" onSelect={this.openInfo.bind(this)}>
+                            <NavDropdown title="More" id="basic-nav-dropdown" onSelect={this.openInfo.bind(this)} alignRight>
                                 <DropdownItem eventKey="about">About Quick-bench</DropdownItem>
                                 <DropdownItem eventKey="benchmark">How to write my benchmarks</DropdownItem>
                                 <Dropdown.Divider />


### PR DESCRIPTION
Since the dropdown menus are all the way on the right, opening the right-most one means that half of the text is off-screen. This commit changes the menu to be right-aligned instead, and changes the other menu for consistency.