### PR TITLE
fix checkedCompiler returning undefined

### DIFF
--- a/components/CompileConfig.js
+++ b/components/CompileConfig.js
@@ -107,7 +107,7 @@ class CompileConfig extends React.Component {
     checkedCompiler(comp) {
         if (!comp)
             return this.state.compiler;
-        if (!this.props.compilers)
+        if (!this.props.compilers || this.props.compilers.length==0)
             return comp;
         if (this.props.compilers.indexOf(comp) > -1)
             return comp;


### PR DESCRIPTION
Check for zero length compiler list.
Without this checkedCompiler returns undefined for local docker-bench runner after initial setup w.o. any compilers pulled yet, crashing the whole frontend.